### PR TITLE
Redshift bins in metal matrix and config builder

### DIFF
--- a/vega/build_config.py
+++ b/vega/build_config.py
@@ -78,8 +78,8 @@ class BuildConfig:
         self.options['rp_only_metal_mats'] = options.get('rp_only_metal_mats', False)
         self.options['metal-matrix'] = options.get('metal-matrix', {})
         self.options['use_metal_bias_eta'] = options.get('use_metal_bias_eta', False)
-        self.options['zmin'] = options.get('zmin', '0.0')
-        self.options['zmax'] = options.get('zmax', '10.0')
+        self.options['zmin'] = options.get('zmin', 0.0)
+        self.options['zmax'] = options.get('zmax', 10.0)
 
         metals = options.get('metals', None)
         if metals is not None:

--- a/vega/build_config.py
+++ b/vega/build_config.py
@@ -78,6 +78,8 @@ class BuildConfig:
         self.options['rp_only_metal_mats'] = options.get('rp_only_metal_mats', False)
         self.options['metal-matrix'] = options.get('metal-matrix', {})
         self.options['use_metal_bias_eta'] = options.get('use_metal_bias_eta', False)
+        self.options['zmin'] = options.get('zmin', '0.0')
+        self.options['zmax'] = options.get('zmax', '10.0')
 
         metals = options.get('metals', None)
         if metals is not None:
@@ -287,6 +289,8 @@ class BuildConfig:
 
                     config['data']['weights-tracer1'] = corr_info.get('weights-tracer1')
                     config['data']['weights-tracer2'] = corr_info.get('weights-tracer2')
+                    config['data']['zmin'] = str(self.options.get('zmin'))
+                    config['data']['zmax'] = str(self.options.get('zmax'))
 
                     config['metal-matrix'] = {}
                     config['metal-matrix']['rebin_factor'] = self.options['metal-matrix'].get(

--- a/vega/metals.py
+++ b/vega/metals.py
@@ -50,6 +50,10 @@ class Metals:
         self.fast_metal_bias = corr_item.config['model'].getboolean('fast_metal_bias', True)
         self.rp_only_metal_mats = corr_item.config['model'].getboolean('rp_only_metal_mats', False)
 
+        # Redshift bins
+        self.zmin = corr_item.config['data'].getfloat('zmin', 0.0)
+        self.zmax = corr_item.config['data'].getfloat('zmax', 10.0)
+
         # Read the growth rate and sigma_smooth from the fiducial config
         if 'growth_rate' in fiducial:
             self.growth_rate = fiducial['growth_rate']
@@ -331,6 +335,9 @@ class Metals:
 
         # Compute weights
         weights = ((weights1 * scaling_1)[:, None] * (weights2 * scaling_2)[None, :]).ravel()
+        zpair = (assumed_z1[:, None] + assumed_z2[None, :]) / 2.
+        zmask = (zpair >= self.zmin) & (zpair <= self.zmax)
+        weights *= zmask.ravel()
 
         # Distortion matrix grid
         rp_bin_edges = np.linspace(

--- a/vega/metals.py
+++ b/vega/metals.py
@@ -472,6 +472,9 @@ class Metals:
 
         # Compute weights
         weights = ((weights1 * scaling_1)[:, None] * (weights2 * scaling_2)[None, :]).ravel()
+        zpair = (assumed_z1[:, None] + assumed_z2[None, :]) / 2.
+        zmask = (zpair >= self.zmin) & (zpair <= self.zmax)
+        weights *= zmask.ravel()
 
         # Distortion matrix grid
         rp_bin_edges = np.linspace(


### PR DESCRIPTION
This PR introduces functionality to account for the redshift range in the metal matrices.
It also adds support for the corresponding configuration flags in the config builder.

**Notes**
These commits were made prior to the recent updates (after October 25). However, since no merge conflicts are currently detected, they should integrate smoothly.