### PR TITLE
Mode marginalization

### DIFF
--- a/vega/build_config.py
+++ b/vega/build_config.py
@@ -238,7 +238,7 @@ class BuildConfig:
         config['cuts']['r-min'] = str(corr_info.get('r-min', 10))
         config['cuts']['r-max'] = str(corr_info.get('r-max', 180))
         config['cuts']['rt-min'] = str(corr_info.get('rt-min', 0))
-        config['cuts']['rp-min'] = str(corr_info.get('rp-min', -200))
+        config['cuts']['rp-min'] = str(corr_info.get('rp-min', -300))
         config['cuts']['mu-min'] = str(corr_info.get('mu-min', -1))
         config['cuts']['mu-max'] = str(corr_info.get('mu-max', 1))
         if self.options['test']:

--- a/vega/build_config.py
+++ b/vega/build_config.py
@@ -61,6 +61,7 @@ class BuildConfig:
         self.options['small_scale_nl'] = options.get('small_scale_nl', False)
         self.options['small_scale_nl_cross'] = options.get('small_scale_nl_cross', False)
         self.options['bao_broadening'] = options.get('bao_broadening', False)
+        self.options['skip-nl-model-in-peak'] = options.get('skip-nl-model-in-peak', False)
         self.options['uv_background'] = options.get('uv_background', False)
         self.options['velocity_dispersion'] = options.get('velocity_dispersion', None)
         self.options['radiation_effects'] = options.get('radiation_effects', False)
@@ -339,6 +340,9 @@ class BuildConfig:
         config['model']['marginalize-above-rpmin'] = str(self.options['marginalize-above-rpmin'])
         config['model']['marginalize-all-rmin-cuts'] = str(
             self.options['marginalize-all-rmin-cuts'])
+
+        if 'skip-nl-model-in-peak' in self.options:
+            config['model']['skip-nl-model-in-peak'] = str(self.options['skip-nl-model-in-peak'])
 
         # P(k) damping scale
         if self.options['pk-damping-scale'] is not None:

--- a/vega/build_config.py
+++ b/vega/build_config.py
@@ -70,6 +70,7 @@ class BuildConfig:
         self.options['marginalize-above-rtmin'] = options.get('marginalize-above-rtmin', 0)
         self.options['marginalize-below-rpmax'] = options.get('marginalize-below-rpmax', 0)
         self.options['marginalize-above-rpmin'] = options.get('marginalize-above-rpmin', 0)
+        self.options['marginalize-all-rmin-cuts'] = options.get('marginalize-all-rmin-cuts', False)
 
         self.options['hcd_model'] = options.get('hcd_model', None)
         self.options['fvoigt_model'] = options.get('fvoigt_model', 'exp')
@@ -336,6 +337,8 @@ class BuildConfig:
         config['model']['marginalize-above-rtmin'] = str(self.options['marginalize-above-rtmin'])
         config['model']['marginalize-below-rpmax'] = str(self.options['marginalize-below-rpmax'])
         config['model']['marginalize-above-rpmin'] = str(self.options['marginalize-above-rpmin'])
+        config['model']['marginalize-all-rmin-cuts'] = str(
+            self.options['marginalize-all-rmin-cuts'])
 
         # P(k) damping scale
         if self.options['pk-damping-scale'] is not None:

--- a/vega/build_config.py
+++ b/vega/build_config.py
@@ -64,10 +64,12 @@ class BuildConfig:
         self.options['uv_background'] = options.get('uv_background', False)
         self.options['velocity_dispersion'] = options.get('velocity_dispersion', None)
         self.options['radiation_effects'] = options.get('radiation_effects', False)
-        self.options['marginalize-small-scales'] = options.get('marginalize-small-scales', False)
-        self.options['single-bin-marg-xi'] = options.get('single-bin-marg-xi', False)
         self.options['pk-damping-scale'] = options.get('pk-damping-scale', None)
         self.options['pk-damping-power'] = options.get('pk-damping-power', 2)
+        self.options['marginalize-below-rtmax'] = options.get('marginalize-below-rtmax', 0)
+        self.options['marginalize-above-rtmin'] = options.get('marginalize-above-rtmin', 0)
+        self.options['marginalize-below-rpmax'] = options.get('marginalize-below-rpmax', 0)
+        self.options['marginalize-above-rpmin'] = options.get('marginalize-above-rpmin', 0)
 
         self.options['hcd_model'] = options.get('hcd_model', None)
         self.options['fvoigt_model'] = options.get('fvoigt_model', 'exp')
@@ -330,8 +332,10 @@ class BuildConfig:
                 config['model']['radiation effects'] = 'True'
 
         # Marginalize small scales
-        config['model']['marginalize-small-scales'] = str(self.options['marginalize-small-scales'])
-        config['model']['single-bin-marg-xi'] = str(self.options['single-bin-marg-xi'])
+        config['model']['marginalize-below-rtmax'] = str(self.options['marginalize-below-rtmax'])
+        config['model']['marginalize-above-rtmin'] = str(self.options['marginalize-above-rtmin'])
+        config['model']['marginalize-below-rpmax'] = str(self.options['marginalize-below-rpmax'])
+        config['model']['marginalize-above-rpmin'] = str(self.options['marginalize-above-rpmin'])
 
         # P(k) damping scale
         if self.options['pk-damping-scale'] is not None:

--- a/vega/coordinates.py
+++ b/vega/coordinates.py
@@ -143,7 +143,7 @@ class Coordinates:
         mask &= (self.rt_grid <= other.rt_max)
         return mask
 
-    def get_mask_scale_cuts(self, cuts_config):
+    def get_mask_scale_cuts(self, cuts_config, small_scale_mask=False):
         """Build mask to apply scale cuts
 
         Parameters
@@ -169,9 +169,14 @@ class Coordinates:
         mu_min_cut = cuts_config.getfloat('mu-min', -1.)
         mu_max_cut = cuts_config.getfloat('mu-max', +1.)
 
-        mask = (self.rp_regular_grid > rp_min_cut) & (self.rp_regular_grid < rp_max_cut)
-        mask &= (self.rt_regular_grid > rt_min_cut) & (self.rt_regular_grid < rt_max_cut)
-        mask &= (self.r_regular_grid > r_min_cut) & (self.r_regular_grid < r_max_cut)
+        mask = (self.rp_regular_grid > rp_min_cut) & (self.rt_regular_grid > rt_min_cut)
+        mask &= (self.r_regular_grid > r_min_cut)
+
+        if small_scale_mask:
+            return mask
+
+        mask &= (self.rp_regular_grid < rp_max_cut) & (self.rt_regular_grid < rt_max_cut)
+        mask &= (self.r_regular_grid < r_max_cut)
         mask &= (self.mu_regular_grid > mu_min_cut) & (self.mu_regular_grid < mu_max_cut)
 
         return mask

--- a/vega/coordinates.py
+++ b/vega/coordinates.py
@@ -158,10 +158,10 @@ class Coordinates:
         """
         # Read the cuts
         rp_min_cut = cuts_config.getfloat('rp-min', 0.)
-        rp_max_cut = cuts_config.getfloat('rp-max', 200.)
+        rp_max_cut = cuts_config.getfloat('rp-max', 300.)
 
         rt_min_cut = cuts_config.getfloat('rt-min', 0.)
-        rt_max_cut = cuts_config.getfloat('rt-max', 200.)
+        rt_max_cut = cuts_config.getfloat('rt-max', 300.)
 
         r_min_cut = cuts_config.getfloat('r-min', 10.)
         r_max_cut = cuts_config.getfloat('r-max', 180.)

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -159,32 +159,32 @@ class CorrelationItem:
             Prior sigma is multiplied to each vector.
         """
         if 'all-rmin' not in self.marginalize_small_scales:
-            indeces = []
+            indices = []
             if 'rtmax' in self.marginalize_small_scales:
                 rtmax = self.marginalize_small_scales['rtmax']
-                indeces += [np.nonzero(
+                indices += [np.nonzero(
                     self.model_coordinates.rt_regular_grid < rtmax
                 )[0]]
 
             if 'rtmin' in self.marginalize_small_scales:
                 rtmin = self.marginalize_small_scales['rtmin']
-                indeces += [np.nonzero(
+                indices += [np.nonzero(
                     self.model_coordinates.rt_regular_grid > rtmin
                 )[0]]
 
             if 'rpmax' in self.marginalize_small_scales:
                 rpmax = self.marginalize_small_scales['rpmax']
-                indeces += [np.nonzero(
+                indices += [np.nonzero(
                     np.abs(self.model_coordinates.rp_regular_grid) < rpmax
                 )[0]]
 
             if 'rpmin' in self.marginalize_small_scales:
                 rpmin = self.marginalize_small_scales['rpmin']
-                indeces += [np.nonzero(
+                indices += [np.nonzero(
                     np.abs(self.model_coordinates.rp_regular_grid) > rpmin
                 )[0]]
 
-            common_idx = reduce(np.intersect1d, indeces)
+            common_idx = reduce(np.intersect1d, indices)
             if common_idx.size == 0:
                 raise ValueError(
                     "No common indices found for small-scale marginalization templates."

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -168,6 +168,11 @@ class CorrelationItem:
             )[0]]
 
         common_idx = reduce(np.intersect1d, indeces)
+        if common_idx.size == 0:
+            raise ValueError(
+                "No common indices found for small-scale marginalization templates."
+            )
+
         templates = []
         for i in common_idx:
             templates.append(coo_array((d, ([0], [i])), shape=(1, N)))

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -156,13 +156,13 @@ class CorrelationItem:
         if 'rpmax' in self.marginalize_small_scales:
             rpmax = self.marginalize_small_scales['rpmax']
             indeces += [np.nonzero(
-                self.model_coordinates.rp_regular_grid < rpmax
+                np.abs(self.model_coordinates.rp_regular_grid) < rpmax
             )[0]]
 
         if 'rpmin' in self.marginalize_small_scales:
             rpmin = self.marginalize_small_scales['rpmin']
             indeces += [np.nonzero(
-                self.model_coordinates.rp_regular_grid > rpmin
+                np.abs(self.model_coordinates.rp_regular_grid) > rpmin
             )[0]]
 
         common_idx = reduce(np.intersect1d, indeces)

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -130,14 +130,14 @@ class CorrelationItem:
 
     def get_undist_xi_marg_templates(self):
         templates = []
-        N = self.dist_model_coordinates.rt_regular_grid.size
+        N = self.model_coordinates.rt_regular_grid.size
         d = np.ones(1)
         # ['rtmax', 'rtmin', 'rpmax', 'rpmin']
 
         if 'rtmax' in self.marginalize_small_scales:
             rtmax = self.marginalize_small_scales['rtmax']
             idx = np.nonzero(
-                self.dist_model_coordinates.rt_regular_grid < rtmax
+                self.model_coordinates.rt_regular_grid < rtmax
             )[0]
             for i in idx:
                 templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
@@ -145,7 +145,7 @@ class CorrelationItem:
         if 'rtmin' in self.marginalize_small_scales:
             rtmin = self.marginalize_small_scales['rtmin']
             idx = np.nonzero(
-                self.dist_model_coordinates.rt_regular_grid > rtmin
+                self.model_coordinates.rt_regular_grid > rtmin
             )[0]
             for i in idx:
                 templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
@@ -153,7 +153,7 @@ class CorrelationItem:
         if 'rpmax' in self.marginalize_small_scales:
             rpmax = self.marginalize_small_scales['rpmax']
             idx = np.nonzero(
-                self.dist_model_coordinates.rp_regular_grid < rpmax
+                self.model_coordinates.rp_regular_grid < rpmax
             )[0]
             for i in idx:
                 templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
@@ -161,7 +161,7 @@ class CorrelationItem:
         if 'rpmin' in self.marginalize_small_scales:
             rpmin = self.marginalize_small_scales['rpmin']
             idx = np.nonzero(
-                self.dist_model_coordinates.rp_regular_grid > rpmin
+                self.model_coordinates.rp_regular_grid > rpmin
             )[0]
             for i in idx:
                 templates.append(coo_array((d, ([0], [i])), shape=(1, N)))

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -62,6 +62,9 @@ class CorrelationItem:
             if marg_rs[i] > 0:
                 self.marginalize_small_scales[name] = marg_rs[i]
 
+        self.marginalize_small_scales_with_cuts = config['model'].getboolean(
+            "marginalize-small-scales-with-cuts", False)
+
         self.has_metals = False
         self.has_bb = False
 
@@ -154,36 +157,45 @@ class CorrelationItem:
         sparse array, likely csc_array
             Prior sigma is multiplied to each vector.
         """
-        indeces = []
+        if not self.marginalize_small_scales_with_cuts:
+            indeces = []
+            if 'rtmax' in self.marginalize_small_scales:
+                rtmax = self.marginalize_small_scales['rtmax']
+                indeces += [np.nonzero(
+                    self.model_coordinates.rt_regular_grid < rtmax
+                )[0]]
 
-        if 'rtmax' in self.marginalize_small_scales:
-            rtmax = self.marginalize_small_scales['rtmax']
-            indeces += [np.nonzero(
-                self.model_coordinates.rt_regular_grid < rtmax
-            )[0]]
+            if 'rtmin' in self.marginalize_small_scales:
+                rtmin = self.marginalize_small_scales['rtmin']
+                indeces += [np.nonzero(
+                    self.model_coordinates.rt_regular_grid > rtmin
+                )[0]]
 
-        if 'rtmin' in self.marginalize_small_scales:
-            rtmin = self.marginalize_small_scales['rtmin']
-            indeces += [np.nonzero(
-                self.model_coordinates.rt_regular_grid > rtmin
-            )[0]]
+            if 'rpmax' in self.marginalize_small_scales:
+                rpmax = self.marginalize_small_scales['rpmax']
+                indeces += [np.nonzero(
+                    np.abs(self.model_coordinates.rp_regular_grid) < rpmax
+                )[0]]
 
-        if 'rpmax' in self.marginalize_small_scales:
-            rpmax = self.marginalize_small_scales['rpmax']
-            indeces += [np.nonzero(
-                np.abs(self.model_coordinates.rp_regular_grid) < rpmax
-            )[0]]
+            if 'rpmin' in self.marginalize_small_scales:
+                rpmin = self.marginalize_small_scales['rpmin']
+                indeces += [np.nonzero(
+                    np.abs(self.model_coordinates.rp_regular_grid) > rpmin
+                )[0]]
 
-        if 'rpmin' in self.marginalize_small_scales:
-            rpmin = self.marginalize_small_scales['rpmin']
-            indeces += [np.nonzero(
-                np.abs(self.model_coordinates.rp_regular_grid) > rpmin
-            )[0]]
-
-        common_idx = reduce(np.intersect1d, indeces)
-        if common_idx.size == 0:
-            raise ValueError(
-                "No common indices found for small-scale marginalization templates."
+            common_idx = reduce(np.intersect1d, indeces)
+            if common_idx.size == 0:
+                raise ValueError(
+                    "No common indices found for small-scale marginalization templates."
+                )
+        else:
+            mask = self.model_coordinates.get_mask_scale_cuts(
+                self.config['cuts']
+            )
+            common_idx = np.nonzero(~mask)[0]
+            print(
+                f"Marginalizing distortion scales with {common_idx.size} points "
+                "based on scale cuts."
             )
 
         N = self.model_coordinates.rt_regular_grid.size

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -190,7 +190,7 @@ class CorrelationItem:
                 )
         else:
             mask = self.model_coordinates.get_mask_scale_cuts(
-                self.config['cuts']
+                self.config['cuts'], small_scale_mask=True
             )
             common_idx = np.nonzero(~mask)[0]
             print(

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -62,8 +62,9 @@ class CorrelationItem:
             if marg_rs[i] > 0:
                 self.marginalize_small_scales[name] = marg_rs[i]
 
-        self.marginalize_small_scales['all-rmin'] = config['model'].getboolean(
-            "marginalize-all-rmin-cuts", False)
+        marginalize_all = config['model'].getboolean("marginalize-all-rmin-cuts", False)
+        if marginalize_all:
+            self.marginalize_small_scales['all-rmin'] = True
 
         self.has_metals = False
         self.has_bb = False
@@ -189,6 +190,8 @@ class CorrelationItem:
                     "No common indices found for small-scale marginalization templates."
                 )
         else:
+            assert self.marginalize_small_scales['all-rmin']
+
             # Initialize the number of bins for each coordinate set
             rp_nbins_dist = self.dist_model_coordinates.rp_nbins
             rt_nbins_dist = self.dist_model_coordinates.rt_nbins

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -156,7 +156,9 @@ class CorrelationItem:
         Returns
         -------
         sparse array, likely csc_array
-            Prior sigma is multiplied to each vector.
+            Sparse matrix of undistorted marginalization templates. Prior sigma
+            is applied in the calling function (e.g. in
+            ``data.get_dist_xi_marg_templates``), not here.
         """
         if 'all-rmin' not in self.marginalize_small_scales:
             indices = []

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -62,8 +62,8 @@ class CorrelationItem:
             if marg_rs[i] > 0:
                 self.marginalize_small_scales[name] = marg_rs[i]
 
-        self.marginalize_small_scales_with_cuts = config['model'].getboolean(
-            "marginalize-small-scales-with-cuts", False)
+        self.marginalize_small_scales['all-rmin'] = config['model'].getboolean(
+            "marginalize-all-rmin-cuts", False)
 
         self.has_metals = False
         self.has_bb = False
@@ -157,7 +157,7 @@ class CorrelationItem:
         sparse array, likely csc_array
             Prior sigma is multiplied to each vector.
         """
-        if not self.marginalize_small_scales_with_cuts:
+        if 'all-rmin' not in self.marginalize_small_scales:
             indeces = []
             if 'rtmax' in self.marginalize_small_scales:
                 rtmax = self.marginalize_small_scales['rtmax']

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -52,8 +52,8 @@ class CorrelationItem:
             config['model'].getfloat("marginalize-below-rpmax", 0),
             config['model'].getfloat("marginalize-above-rpmin", 0)
         ]
-        self.marginalize_small_scales_prior_var = config['model'].getfloat(
-            "marginalize-prior-variance", 0)
+        self.marginalize_small_scales_prior_sigma = config['model'].getfloat(
+            "marginalize-prior-sigma", 10.0)
         self.marginalize_small_scales = {}
         for i, name in enumerate(['rtmax', 'rtmin', 'rpmax', 'rpmin']):
             if marg_rs[i] > 0:

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -45,10 +45,19 @@ class CorrelationItem:
                 self.tracer2['weights-path'] = self.tracer1['weights-path']
 
         self.test_flag = config['data'].getboolean('test', False)
-        self.marginalize_small_scales = config['model'].getboolean(
-            'marginalize-small-scales', False)
-        self.single_bin_marg_xi = config['model'].getboolean(
-            'single-bin-marg-xi', False)
+
+        marg_rs = [
+            config['model'].getfloat("marginalize-below-rtmax", 0),
+            config['model'].getfloat("marginalize-above-rtmin", 0),
+            config['model'].getfloat("marginalize-below-rpmax", 0),
+            config['model'].getfloat("marginalize-above-rpmin", 0)
+        ]
+        self.marginalize_small_scales_prior_var = config['model'].getfloat(
+            "marginalize-prior-variance", 0)
+        self.marginalize_small_scales = {}
+        for i, name in enumerate(['rtmax', 'rtmin', 'rpmax', 'rpmin']):
+            if marg_rs[i] > 0:
+                self.marginalize_small_scales[name] = marg_rs[i]
 
         self.has_metals = False
         self.has_bb = False

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -208,7 +208,7 @@ class CorrelationItem:
                     mask_model[i*cb:i*cb+cb, j*cb:j*cb+cb] = mask_dist_model[i, j]
 
             # Get the common indices for the bins to marginalize over
-            common_idx = np.nonzero(~mask_model.reshape(rp_nbins*rt_nbins))[0]
+            common_idx = np.nonzero(~mask_model.reshape(rp_nbins*rt_nbins).astype(bool))[0]
             print(
                 f"Marginalizing distortion scales with {common_idx.size} points "
                 "based on scale cuts."

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse import coo_array, vstack as sparse_vstack
+from scipy.sparse import coo_array
 from picca import constants as picca_constants
 from functools import reduce
 
@@ -139,8 +139,6 @@ class CorrelationItem:
         sparse array, likely csc_array
             Prior sigma is multiplied to each vector.
         """
-        N = self.model_coordinates.rt_regular_grid.size
-        d = np.ones(1)  # required in coo_array construction
         indeces = []
 
         if 'rtmax' in self.marginalize_small_scales:
@@ -173,9 +171,12 @@ class CorrelationItem:
                 "No common indices found for small-scale marginalization templates."
             )
 
-        templates = []
-        for i in common_idx:
-            templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
+        N = self.model_coordinates.rt_regular_grid.size
+        d = np.ones(common_idx.size)
+
+        templates = coo_array(
+            (d, (np.arange(d.size), common_idx)), shape=(d.size, N)
+        ).tocsr().T
 
         a = self.marginalize_small_scales_prior_sigma
-        return a * sparse_vstack(templates).tocsr().T
+        return a * templates

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -224,5 +224,4 @@ class CorrelationItem:
             (d, (np.arange(d.size), common_idx)), shape=(d.size, N)
         ).tocsr().T
 
-        a = self.marginalize_small_scales_prior_sigma
-        return a * templates
+        return templates

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -129,10 +129,18 @@ class CorrelationItem:
         return False
 
     def get_undist_xi_marg_templates(self):
+        """Calculate undistorted correlation function marginalization templates.
+        Degenerate modes are removed in the (relevant) distorted space in
+            data.get_dist_xi_marg_templates function.
+
+        Returns
+        -------
+        sparse array, likely csc_array
+            Prior sigma is multiplied to each vector.
+        """
         templates = []
         N = self.model_coordinates.rt_regular_grid.size
-        d = np.ones(1)
-        # ['rtmax', 'rtmin', 'rpmax', 'rpmin']
+        d = np.ones(1)  # required in coo_array construction
 
         if 'rtmax' in self.marginalize_small_scales:
             rtmax = self.marginalize_small_scales['rtmax']
@@ -166,6 +174,5 @@ class CorrelationItem:
             for i in idx:
                 templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
 
-        # SVD to cut off degen modes?
         a = self.marginalize_small_scales_prior_sigma
         return a * sparse_vstack(templates).tocsr().T

--- a/vega/data.py
+++ b/vega/data.py
@@ -673,6 +673,8 @@ class Data:
         if not return_AAT:
             return templates.toarray()
 
+        templates *= self.corr_item.marginalize_small_scales_prior_sigma
+
         # Compress using svd to remove degenerate modes
         templates = templates[self.model_mask, :].toarray()
         print(f"  There are {templates.shape[1]} templates. "

--- a/vega/data.py
+++ b/vega/data.py
@@ -82,7 +82,10 @@ class Data:
             cov_update = self.get_dist_xi_marg_templates()
             cov_update = cov_update[self.model_mask, :][:, self.model_mask]
             w = np.logical_and.outer(self.data_mask, self.data_mask)
-            self._cov_mat[w] += cov_update.ravel()
+            self.cov_marg_update = cov_update.ravel()
+            self._cov_mat[w] += self.cov_marg_update
+        else:
+            self.cov_marg_update = None
 
         self._cholesky = None
         self._scale = 1.

--- a/vega/data.py
+++ b/vega/data.py
@@ -655,8 +655,10 @@ class Data:
         templates = self.distortion_mat.dot(templates)
 
         # Compress using svd to remove degenerate modes
+        print("  SVD of template matrix to remove degenerate modes.")
         u, s, vh = np.linalg.svd(templates.toarray(), full_matrices=False)
         w = s > 1e-5 * s[0]
+        print(f"  Removed {w.size - w.sum()} out of {w.size} modes.")
 
         if return_AAT:
             del vh

--- a/vega/data.py
+++ b/vega/data.py
@@ -80,8 +80,7 @@ class Data:
         if corr_item.marginalize_small_scales:
             print('Updating covariance with marginalization templates.')
             cov_update = self.get_dist_xi_marg_templates()
-            cov_update = cov_update[np.ix_(self.model_mask, self.model_mask)]
-            self.cov_marg_update = cov_update.ravel()
+            self.cov_marg_update = cov_update[np.ix_(self.model_mask, self.model_mask)]
             self._cov_mat[np.ix_(self.data_mask, self.data_mask)] += self.cov_marg_update
         else:
             self.cov_marg_update = None

--- a/vega/data.py
+++ b/vega/data.py
@@ -78,11 +78,12 @@ class Data:
             self._cov_mat = np.eye(self.full_data_size)
 
         if corr_item.marginalize_small_scales:
+            print('Updating covariance with marginalization templates.')
             templates = self.get_dist_xi_marg_templates()
             cov_update = templates.dot(templates.T)
             cov_update = cov_update[self.model_mask, :][:, self.model_mask]
             w = np.logical_and.outer(self.data_mask, self.data_mask)
-            self._cov_mat[w] += cov_update.ravel()
+            self._cov_mat[w] += cov_update.toarray().ravel()
 
         self._cholesky = None
         self._scale = 1.

--- a/vega/data.py
+++ b/vega/data.py
@@ -662,8 +662,10 @@ class Data:
         2D np.array
             Template or covariance update matrix.
         """
-        assert self.corr_item.marginalize_small_scales
-        assert self.has_distortion
+        if not self.corr_item.marginalize_small_scales:
+            raise ValueError("Marginalization not configured")
+        if not self.has_distortion:
+            raise ValueError("Distortion matrix required for marginalization")
 
         templates = self.corr_item.get_undist_xi_marg_templates()
         templates = self.distortion_mat.dot(templates)

--- a/vega/data.py
+++ b/vega/data.py
@@ -79,7 +79,10 @@ class Data:
 
         if corr_item.marginalize_small_scales:
             templates = self.get_dist_xi_marg_templates()
-            self._cov_mat += templates.dot(templates.T)
+            cov_update = templates.dot(templates.T)
+            cov_update = cov_update[self.model_mask, :][:, self.model_mask]
+            w = np.logical_and.outer(self..data_mask, self..data_mask)
+            self._cov_mat[w] += cov_update
 
         self._cholesky = None
         self._scale = 1.

--- a/vega/data.py
+++ b/vega/data.py
@@ -671,24 +671,25 @@ class Data:
         return self.mc_mock
 
     def get_dist_xi_marg_templates(self, factor=1e-8, return_AAT=True):
-        """Multiply undistorted templates with the distortion matrix and
-        return either 1) full template matrix or 1 + 2) compressed A . A^T that
-        updates the covariance matrix.
+        """Multiply undistorted templates with the distortion matrix and return
+        either the distorted template matrix alone or, additionally, the
+        compressed covariance-update matrix A @ A^T, depending on ``return_AAT``.
 
         Parameters
         ----------
         factor: float, default: 1e-8
             Compression cut-off ratio with respect to the highest singular value.
         return_AAT : bool, optional
-            If True (default), also returns the covariance update matrix (A @ A^T).
-            If False, returns the template matrix.
+            If True (default), also returns the covariance update matrix (A @ A^T)
+            and the function returns a tuple ``(templates, cov_update)``.
+            If False, returns only the template matrix.
 
         Returns
         -------
         templates: csr_array
-            Template matrix
+            Template matrix.
         cov_update (optional): 2D np.array
-            Covariance update matrix.
+            Covariance update matrix, returned only when ``return_AAT`` is True.
         """
         if not self.corr_item.marginalize_small_scales:
             raise ValueError("Marginalization not configured")

--- a/vega/data.py
+++ b/vega/data.py
@@ -89,6 +89,7 @@ class Data:
         self._scale = 1.
         self.scaled_inv_masked_cov = None
         self.scaled_log_cov_det = None
+        self.effective_data_size = self.data_size - self.num_marg_modes
 
     @property
     def blind(self):

--- a/vega/data.py
+++ b/vega/data.py
@@ -79,7 +79,7 @@ class Data:
 
         if corr_item.marginalize_small_scales:
             print('Updating covariance with marginalization templates.')
-            cov_update = self.get_dist_xi_marg_templates(return_AAT=True)
+            cov_update = self.get_dist_xi_marg_templates()
             cov_update = cov_update[self.model_mask, :][:, self.model_mask]
             w = np.logical_and.outer(self.data_mask, self.data_mask)
             self._cov_mat[w] += cov_update.ravel()
@@ -642,7 +642,7 @@ class Data:
 
         return self.mc_mock
 
-    def get_dist_xi_marg_templates(self, factor=1e-5, return_AAT=False):
+    def get_dist_xi_marg_templates(self, factor=1e-8, return_AAT=True):
         """
         Returns
         -------
@@ -657,7 +657,7 @@ class Data:
         # Compress using svd to remove degenerate modes
         print("  SVD of template matrix to remove degenerate modes.")
         u, s, vh = np.linalg.svd(templates.toarray(), full_matrices=False)
-        w = s > 1e-5 * s[0]
+        w = s > factor * s[0]
         print(f"  Removed {w.size - w.sum()} out of {w.size} modes.")
 
         if return_AAT:

--- a/vega/data.py
+++ b/vega/data.py
@@ -80,6 +80,7 @@ class Data:
         self.variance = self.cov_mat.diagonal()
 
         if corr_item.marginalize_small_scales:
+            self.cov_mat_org = self.cov_mat.copy()
             print('Updating covariance with marginalization templates.')
             self.marg_templates, self.cov_marg_update = self.get_dist_xi_marg_templates()
             ntemps = self.marg_templates.shape[1]
@@ -104,6 +105,7 @@ class Data:
             # is given by marg_templates.dot(marg_diff2coeff_matrix.dot(diff))
             self.marg_diff2coeff_matrix = Ainv.dot(G)
         else:
+            self.cov_mat_org = self.cov_mat
             self.marg_templates = None
             self.cov_marg_update = None
             self.marg_diff2coeff_matrix = None

--- a/vega/data.py
+++ b/vega/data.py
@@ -675,7 +675,7 @@ class Data:
 
         # Compress using svd to remove degenerate modes
         templates = templates[self.model_mask, :].toarray()
-        print(f"  There are {templates.shape[1].size} templates. "
+        print(f"  There are {templates.shape[1]} templates. "
               "SVD of template matrix to remove degenerate modes.")
         u, s, _ = np.linalg.svd(templates, full_matrices=False)
         w = s > factor * s[0]

--- a/vega/data.py
+++ b/vega/data.py
@@ -77,6 +77,10 @@ class Data:
         if not self.has_cov_mat and not self.corr_item.low_mem_mode:
             self._cov_mat = np.eye(self.full_data_size)
 
+        if corr_item.marginalize_small_scales:
+            templates = self.get_dist_xi_marg_templates()
+            self._cov_mat += templates.dot(templates.T)
+
         self._cholesky = None
         self._scale = 1.
         self.scaled_inv_masked_cov = None
@@ -634,3 +638,10 @@ class Data:
         self.masked_mc_mock = self.mc_mock[self.data_mask]
 
         return self.mc_mock
+
+    def get_dist_xi_marg_templates(self):
+        assert self.corr_item.marginalize_small_scales
+        assert self.has_distortion
+
+        templates = self.corr_item.get_undist_xi_marg_templates()
+        return self.distortion_mat.dot(templates)

--- a/vega/data.py
+++ b/vega/data.py
@@ -675,7 +675,8 @@ class Data:
 
         # Compress using svd to remove degenerate modes
         templates = templates[self.model_mask, :].toarray()
-        print(f"  There are {w.size} templates. SVD of template matrix to remove degenerate modes.")
+        print(f"  There are {templates.shape[1].size} templates. "
+              "SVD of template matrix to remove degenerate modes.")
         u, s, _ = np.linalg.svd(templates, full_matrices=False)
         w = s > factor * s[0]
         u = u[:, w]

--- a/vega/data.py
+++ b/vega/data.py
@@ -81,7 +81,7 @@ class Data:
             templates = self.get_dist_xi_marg_templates()
             cov_update = templates.dot(templates.T)
             cov_update = cov_update[self.model_mask, :][:, self.model_mask]
-            w = np.logical_and.outer(self..data_mask, self..data_mask)
+            w = np.logical_and.outer(self.data_mask, self.data_mask)
             self._cov_mat[w] += cov_update
 
         self._cholesky = None

--- a/vega/data.py
+++ b/vega/data.py
@@ -2,7 +2,7 @@ import numpy as np
 from astropy.io import fits
 from scipy import linalg
 from scipy import sparse
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 from vega.utils import find_file, compute_masked_invcov, compute_log_cov_det
 from vega.coordinates import Coordinates
@@ -263,9 +263,9 @@ class Data:
 
         if dmat_path is None:
             if 'DM_BLIND' in hdul[1].columns.names:
-                self._distortion_mat = csr_matrix(hdul[1].data['DM_BLIND'].astype(float))
+                self._distortion_mat = csr_array(hdul[1].data['DM_BLIND'].astype(float))
             elif 'DM' in hdul[1].columns.names:
-                self._distortion_mat = csr_matrix(hdul[1].data['DM'].astype(float))
+                self._distortion_mat = csr_array(hdul[1].data['DM'].astype(float))
 
         # Read the covariance matrix
         if not self.corr_item.low_mem_mode:
@@ -361,9 +361,9 @@ class Data:
             self._check_if_blinding_matches(header['BLINDING'], dmat_path)
 
         if 'DM' in hdul[1].columns.names:
-            self._distortion_mat = csr_matrix(hdul[1].data['DM'].astype(float))
+            self._distortion_mat = csr_array(hdul[1].data['DM'].astype(float))
         elif 'DM_BLIND' in hdul[1].columns.names:
-            self._distortion_mat = csr_matrix(hdul[1].data['DM_BLIND'].astype(float))
+            self._distortion_mat = csr_array(hdul[1].data['DM_BLIND'].astype(float))
         else:
             raise ValueError('No DM or DM_BLIND column found in distortion matrix file.')
 
@@ -553,9 +553,9 @@ class Data:
 
         dm_name = dm_prefix + name
         if dm_name in metal_hdul[2].columns.names:
-            self.metal_mats[tracers] = csr_matrix(metal_hdul[2].data[dm_name])
+            self.metal_mats[tracers] = csr_array(metal_hdul[2].data[dm_name])
         elif len(metal_hdul) > 3 and dm_name in metal_hdul[3].columns.names:
-            self.metal_mats[tracers] = csr_matrix(metal_hdul[3].data[dm_name])
+            self.metal_mats[tracers] = csr_array(metal_hdul[3].data[dm_name])
         elif self.corr_item.test_flag:
             self.metal_mats[tracers] = sparse.eye(metal_mat_size)
         else:

--- a/vega/data.py
+++ b/vega/data.py
@@ -82,7 +82,7 @@ class Data:
             cov_update = templates.dot(templates.T)
             cov_update = cov_update[self.model_mask, :][:, self.model_mask]
             w = np.logical_and.outer(self.data_mask, self.data_mask)
-            self._cov_mat[w] += cov_update
+            self._cov_mat[w] += cov_update.ravel()
 
         self._cholesky = None
         self._scale = 1.

--- a/vega/data.py
+++ b/vega/data.py
@@ -646,10 +646,21 @@ class Data:
         return self.mc_mock
 
     def get_dist_xi_marg_templates(self, factor=1e-8, return_AAT=True):
-        """
+        """Multiply undistorted templates with the distortion matrix and
+        return either 1) compressed template matrix or 2) A . A^T that updates
+        the covariance matrix.
+
+        Parameters
+        ----------
+        factor: float
+            Compression cut-off ratio with respect to the highes singular value.
+        return_AAT : bool, default: True
+            Returns covariance update matrix if true.
+
         Returns
         -------
         2D np.array
+            Template or covariance update matrix.
         """
         assert self.corr_item.marginalize_small_scales
         assert self.has_distortion

--- a/vega/model.py
+++ b/vega/model.py
@@ -83,6 +83,8 @@ class Model:
         if corr_item.marginalize_small_scales:
             assert self._has_distortion_mat
             self._init_marg_xi_templates()
+        else:
+            self.marginalization_templates = None
 
     def _compute_model(self, pars, pk_lin, component='smooth', xi_metals=None):
         """Compute a model correlation function given the input pars
@@ -265,7 +267,8 @@ class Model:
                 templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
 
         templates = sparse_vstack(templates).tocsr().T
-        self.templates = self._data.distortion_mat.dot(templates)
+        self.marginalization_templates = self._data.distortion_mat.dot(templates)
+        self.marginalization_templates *= self._corr_item.marginalize_small_scales_prior_sigma
         # SVD to cut off degen modes?
 
     def _init_marg_xi_params(self, marg_pars):

--- a/vega/model.py
+++ b/vega/model.py
@@ -80,6 +80,10 @@ class Model:
         self._instrumental_systematics_flag = corr_item.config['model'].getboolean(
             'desi-instrumental-systematics', False)
 
+        if corr_item.marginalize_small_scales:
+            assert self._has_distortion_mat
+            self._init_marg_xi_templates()
+
     def _compute_model(self, pars, pk_lin, component='smooth', xi_metals=None):
         """Compute a model correlation function given the input pars
         and a fiducial linear power spectrum.
@@ -143,14 +147,14 @@ class Model:
             xi_model *= self.broadband.compute(pars, 'pre-mul')
             xi_model += self.broadband.compute(pars, 'pre-add')
 
-        if self._corr_item.marginalize_small_scales:
-            if self._marg_par_names is None:
-                self._init_marg_xi_params(pars)
+        # if self._corr_item.marginalize_small_scales:
+        #     if self._marg_par_names is None:
+        #         self._init_marg_xi_params(pars)
 
-            if self._marg_par_names:
-                assert self._has_distortion_mat
-                xi_marg_pars = np.array([pars[name] for name in self._marg_par_names])
-                xi_model[self._marg_xi_mask] = xi_marg_pars
+        #     if self._marg_par_names:
+        #         assert self._has_distortion_mat
+        #         xi_marg_pars = np.array([pars[name] for name in self._marg_par_names])
+        #         xi_model[self._marg_xi_mask] = xi_marg_pars
 
         # Apply the distortion matrix
         if self._has_distortion_mat:
@@ -219,6 +223,48 @@ class Model:
         xi_full = self._compute_model(pars, pk_full, 'full')
 
         return xi_full
+
+    def _init_marg_xi_templates(self):
+        from scipy.sparse import coo_array, vstack as sparse_vstack
+        templates = []
+        N = self._corr_item.dist_model_coordinates.rt_regular_grid.size
+        # ['rtmax', 'rtmin', 'rpmax', 'rpmin']
+
+        if 'rtmax' in self._corr_item.marginalize_small_scales:
+            rtmax = self._corr_item.marginalize_small_scales['rtmax']
+            idx = np.nonzero(
+                self._corr_item.dist_model_coordinates.rt_regular_grid < rtmax
+            )[0]
+            for i in idx:
+                templates.append(coo_array((1.0, i), shape=N))
+
+        if 'rtmin' in self._corr_item.marginalize_small_scales:
+            rtmin = self._corr_item.marginalize_small_scales['rtmin']
+            idx = np.nonzero(
+                self._corr_item.dist_model_coordinates.rt_regular_grid > rtmin
+            )[0]
+            for i in idx:
+                templates.append(coo_array((1.0, i), shape=N))
+
+        if 'rpmax' in self._corr_item.marginalize_small_scales:
+            rpmax = self._corr_item.marginalize_small_scales['rpmax']
+            idx = np.nonzero(
+                self._corr_item.dist_model_coordinates.rp_regular_grid < rpmax
+            )[0]
+            for i in idx:
+                templates.append(coo_array((1.0, i), shape=N))
+
+        if 'rpmin' in self._corr_item.marginalize_small_scales:
+            rpmin = self._corr_item.marginalize_small_scales['rpmin']
+            idx = np.nonzero(
+                self._corr_item.dist_model_coordinates.rp_regular_grid > rpmin
+            )[0]
+            for i in idx:
+                templates.append(coo_array((1.0, i), shape=N))
+
+        templates = sparse_vstack(sparse_vstack).tocsr().T
+        self.templates = self._data.distortion_mat.dot(templates)
+        # SVD to cut off degen modes?
 
     def _init_marg_xi_params(self, marg_pars):
         rp_nbins_dist = self._corr_item.dist_model_coordinates.rp_nbins

--- a/vega/model.py
+++ b/vega/model.py
@@ -226,8 +226,10 @@ class Model:
 
     def _init_marg_xi_templates(self):
         from scipy.sparse import coo_array, vstack as sparse_vstack
+
         templates = []
         N = self._corr_item.dist_model_coordinates.rt_regular_grid.size
+        d = np.ones(1)
         # ['rtmax', 'rtmin', 'rpmax', 'rpmin']
 
         if 'rtmax' in self._corr_item.marginalize_small_scales:
@@ -236,7 +238,7 @@ class Model:
                 self._corr_item.dist_model_coordinates.rt_regular_grid < rtmax
             )[0]
             for i in idx:
-                templates.append(coo_array((1.0, i), shape=N))
+                templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
 
         if 'rtmin' in self._corr_item.marginalize_small_scales:
             rtmin = self._corr_item.marginalize_small_scales['rtmin']
@@ -244,7 +246,7 @@ class Model:
                 self._corr_item.dist_model_coordinates.rt_regular_grid > rtmin
             )[0]
             for i in idx:
-                templates.append(coo_array((1.0, i), shape=N))
+                templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
 
         if 'rpmax' in self._corr_item.marginalize_small_scales:
             rpmax = self._corr_item.marginalize_small_scales['rpmax']
@@ -252,7 +254,7 @@ class Model:
                 self._corr_item.dist_model_coordinates.rp_regular_grid < rpmax
             )[0]
             for i in idx:
-                templates.append(coo_array((1.0, i), shape=N))
+                templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
 
         if 'rpmin' in self._corr_item.marginalize_small_scales:
             rpmin = self._corr_item.marginalize_small_scales['rpmin']
@@ -260,9 +262,9 @@ class Model:
                 self._corr_item.dist_model_coordinates.rp_regular_grid > rpmin
             )[0]
             for i in idx:
-                templates.append(coo_array((1.0, i), shape=N))
+                templates.append(coo_array((d, ([0], [i])), shape=(1, N)))
 
-        templates = sparse_vstack(sparse_vstack).tocsr().T
+        templates = sparse_vstack(templates).tocsr().T
         self.templates = self._data.distortion_mat.dot(templates)
         # SVD to cut off degen modes?
 

--- a/vega/model.py
+++ b/vega/model.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from . import power_spectrum
 from . import pktoxi
 from . import correlation_func as corr_func
@@ -11,8 +9,6 @@ class Model:
     """
     Class for computing Lyman-alpha forest correlation function models.
     """
-    _marg_par_names = None
-    _marg_xi_mask = None
 
     def __init__(self, corr_item, fiducial, scale_params, data=None):
         """
@@ -143,15 +139,6 @@ class Model:
             xi_model *= self.broadband.compute(pars, 'pre-mul')
             xi_model += self.broadband.compute(pars, 'pre-add')
 
-        # if self._corr_item.marginalize_small_scales:
-        #     if self._marg_par_names is None:
-        #         self._init_marg_xi_params(pars)
-
-        #     if self._marg_par_names:
-        #         assert self._has_distortion_mat
-        #         xi_marg_pars = np.array([pars[name] for name in self._marg_par_names])
-        #         xi_model[self._marg_xi_mask] = xi_marg_pars
-
         # Apply the distortion matrix
         if self._has_distortion_mat:
             xi_model = self._data.distortion_mat.dot(xi_model)
@@ -219,49 +206,3 @@ class Model:
         xi_full = self._compute_model(pars, pk_full, 'full')
 
         return xi_full
-
-    def _init_marg_xi_params(self, marg_pars):
-        rp_nbins_dist = self._corr_item.dist_model_coordinates.rp_nbins
-        rt_nbins_dist = self._corr_item.dist_model_coordinates.rt_nbins
-        rp_nbins = self._corr_item.model_coordinates.rp_nbins
-        rt_nbins = self._corr_item.model_coordinates.rt_nbins
-
-        mask = np.zeros_like(
-            self._corr_item.model_coordinates.r_grid).astype(bool).reshape(rp_nbins, rt_nbins)
-        names = []
-
-        cb = rp_nbins // self._corr_item.dist_model_coordinates.rp_nbins
-        if self._corr_item.single_bin_marg_xi:
-            for i in range(rp_nbins_dist):
-                for j in range(rt_nbins_dist):
-                    par_name = f'bias_xi_{i}_{j}'
-                    if par_name in marg_pars:
-                        mask[i*cb:i*cb+cb, j*cb:j*cb+cb] = True
-                        print(mask[i*cb:i*cb+cb, j*cb:j*cb+cb])
-                        names += [par_name] * mask[i*cb:i*cb+cb, j*cb:j*cb+cb].size
-        else:
-            for i in range(rp_nbins):
-                for j in range(rt_nbins):
-                    par_name = f'bias_xi_{i}_{j}'
-                    if par_name in marg_pars:
-                        mask[i, j] = True
-                        names.append(par_name)
-
-        self._marg_par_names = names
-        self._marg_xi_mask = mask.reshape(int(rp_nbins * rt_nbins))
-        rp_nbins = self._corr_item.model_coordinates.rp_nbins
-        rt_nbins = self._corr_item.model_coordinates.rt_nbins
-        corr_name = self._corr_item.name
-        mask = np.zeros_like(
-            self._corr_item.model_coordinates.r_grid).astype(bool).reshape(rp_nbins, rt_nbins)
-        names = []
-
-        for i in range(rp_nbins):
-            for j in range(rt_nbins):
-                par_name = f'bias_xi_{corr_name}_{i}_{j}'
-                if par_name in marg_pars:
-                    mask[i, j] = True
-                    names.append(par_name)
-
-        self._marg_par_names = names
-        self._marg_xi_mask = mask.reshape(int(rp_nbins * rt_nbins))

--- a/vega/output.py
+++ b/vega/output.py
@@ -89,7 +89,7 @@ class Output:
                              ' Reinitialize with a valid vega.data object.')
 
         primary_hdu = fits.PrimaryHDU()
-        model_hdus = self._model_hdu(corr_funcs, params, bestfit_corr_stats)
+        model_hdus = self._model_hdus(corr_funcs, params, bestfit_corr_stats)
         hdu_list = [primary_hdu] + model_hdus
 
         if minimizer is not None:

--- a/vega/output.py
+++ b/vega/output.py
@@ -204,8 +204,8 @@ class Output:
                 for par, val in bestfit_corr_stats[name].items():
                     if par == 'bestfit_marg_coeff':
                         names = [f'marg_coeff_{i}' for i in range(len(val))]
-                        for name, v in zip(names, val):
-                            card_name = 'hierarch ' + name
+                        for coeff_name, v in zip(names, val):
+                            card_name = 'hierarch ' + coeff_name
                             model_hdu.header[card_name] = v
                     else:
                         card_name = 'hierarch ' + par

--- a/vega/output.py
+++ b/vega/output.py
@@ -196,9 +196,6 @@ class Output:
             model_hdu = fits.BinTableHDU.from_columns(columns)
             model_hdu.name = 'MODEL_' + name
 
-            card_name = 'hierarch ' + '_size'
-            model_hdu.header[card_name] = num_rows
-
             for par, val in params.items():
                 card_name = 'hierarch ' + par
                 model_hdu.header[card_name] = val

--- a/vega/output.py
+++ b/vega/output.py
@@ -190,7 +190,7 @@ class Output:
             if self.data[name].nb is not None:
                 columns.append(fits.Column(
                     name=name+'_NB', format='K',
-                    array=self.pad_array(self.data[name].nb, num_rows)
+                    array=self.pad_array(self.data[name].nb, num_rows, pad_value=0)
                 ))
 
             model_hdu = fits.BinTableHDU.from_columns(columns)

--- a/vega/output.py
+++ b/vega/output.py
@@ -203,6 +203,8 @@ class Output:
             if bestfit_corr_stats is not None:
                 for par, val in bestfit_corr_stats[name].items():
                     if par == 'bestfit_marg_coeff':
+                        if val is None:
+                            continue
                         names = [f'marg_coeff_{i}' for i in range(len(val))]
                         for coeff_name, v in zip(names, val):
                             card_name = 'hierarch ' + coeff_name

--- a/vega/output.py
+++ b/vega/output.py
@@ -157,7 +157,7 @@ class Output:
             ))
             columns.append(fits.Column(
                 name=name+'_VAR', format='D',
-                array=self.pad_array(self.data[name].cov_mat.diagonal(), num_rows)
+                array=self.pad_array(self.data[name].variance, num_rows)
             ))
 
             columns.append(fits.Column(

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -36,7 +36,7 @@ class VegaPlots:
                 self.cross_flag[name] = cross_flag
                 self.data[name] = data.data_vec
                 if data.has_cov_mat:
-                    self.cov_mat[name] = data.cov_mat
+                    self.cov_mat[name] = data.cov_mat_org
 
                 # Initialize data coordinates
                 self.rp_setup_data[name], self.rt_setup_data[name], self.r_setup_data[name] = \

--- a/vega/postprocess/fit_results.py
+++ b/vega/postprocess/fit_results.py
@@ -86,13 +86,13 @@ class FitResults:
             reduced_chisq = hdu.header.get('HIERARCH REDUCED_CHISQ', None)
             p_value = hdu.header.get('HIERARCH P_VALUE', None)
 
-            if 'HIERARCH BESTFIT_MARG_COEFF_0' in hdu.header:
-                marg_coeffs = []
+            bestfit_marg_coeff = []
+            if 'HIERARCH marg_coeff_0' in hdu.header:
                 i = 0
-                while f'HIERARCH BESTFIT_MARG_COEFF_{i}' in hdu.header:
-                    marg_coeffs.append(hdu.header[f'HIERARCH BESTFIT_MARG_COEFF_{i}'])
+                while f'HIERARCH marg_coeff_{i}' in hdu.header:
+                    bestfit_marg_coeff.append(hdu.header[f'HIERARCH marg_coeff_{i}'])
                     i += 1
-                bestfit_marg_coeff = np.array(marg_coeffs)
+            bestfit_marg_coeff = np.array(bestfit_marg_coeff)
 
             self.correlations[corr_name] = CorrelationOutput(
                 model, model_mask, data, data_mask, variance, rp, rt, z,

--- a/vega/postprocess/fit_results.py
+++ b/vega/postprocess/fit_results.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.stats as stats
 from astropy.io import fits
 from getdist import MCSamples
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Union
 from numpy.typing import ArrayLike
 

--- a/vega/postprocess/fit_results.py
+++ b/vega/postprocess/fit_results.py
@@ -43,6 +43,7 @@ class FitResults:
             name: value for name, value in zip(self.names, hdul['BESTFIT'].data['errors'])}
         self.num_pars = len(self.names)
 
+        self.marg_coeff = {}
         if not results_only:
             self.read_correlations(hdul)
 
@@ -95,6 +96,7 @@ class FitResults:
             bestfit_marg_coeff = np.array(bestfit_marg_coeff)
 
             lowercase_name = corr_name.lower()
+            self.marg_coeff[lowercase_name] = bestfit_marg_coeff
             self.correlations[lowercase_name] = CorrelationOutput(
                 model, model_mask, data, data_mask, variance, rp, rt, z,
                 size=size, chisq=chisq, reduced_chisq=reduced_chisq,

--- a/vega/postprocess/fit_results.py
+++ b/vega/postprocess/fit_results.py
@@ -94,7 +94,8 @@ class FitResults:
                     i += 1
             bestfit_marg_coeff = np.array(bestfit_marg_coeff)
 
-            self.correlations[corr_name] = CorrelationOutput(
+            lowercase_name = corr_name.lower()
+            self.correlations[lowercase_name] = CorrelationOutput(
                 model, model_mask, data, data_mask, variance, rp, rt, z,
                 size=size, chisq=chisq, reduced_chisq=reduced_chisq,
                 p_value=p_value, bestfit_marg_coeff=bestfit_marg_coeff

--- a/vega/postprocess/fit_results.py
+++ b/vega/postprocess/fit_results.py
@@ -69,7 +69,7 @@ class FitResults:
         self.correlations = {}
         self.num_data_points = 0
         for hdu in model_hdus:
-            corr_name = hdu.name.split('_')[1]
+            corr_name = hdu.name.split('_', 1)[1]
 
             model = hdu.data[corr_name + '_MODEL']
             model_mask = hdu.data[corr_name + '_MODEL_MASK']

--- a/vega/postprocess/fit_results.py
+++ b/vega/postprocess/fit_results.py
@@ -2,7 +2,8 @@ import numpy as np
 import scipy.stats as stats
 from astropy.io import fits
 from getdist import MCSamples
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Union
 from numpy.typing import ArrayLike
 
 from vega.utils import find_file
@@ -20,23 +21,30 @@ class CorrelationOutput:
     rt: ArrayLike
     z: ArrayLike
 
+    size: Union[int, None] = None
+    chisq: Union[float, None] = None
+    reduced_chisq: Union[float, None] = None
+    p_value: Union[float, None] = None
+    bestfit_marg_coeff: Union[ArrayLike, None] = None
+
 
 class FitResults:
     def __init__(self, path, results_only=False):
         hdul = fits.open(find_file(path))
 
-        self.chisq = hdul[2].header['FVAL']
-        self.valid = hdul[2].header['VALID']
-        self.accurate = hdul[2].header['ACCURATE']
-        self.names = hdul[2].data['names']
-        self.mean = hdul[2].data['values']
-        self.cov = hdul[2].data['covariance']
+        self.chisq = hdul['BESTFIT'].header['FVAL']
+        self.valid = hdul['BESTFIT'].header['VALID']
+        self.accurate = hdul['BESTFIT'].header['ACCURATE']
+        self.names = hdul['BESTFIT'].data['names']
+        self.mean = hdul['BESTFIT'].data['values']
+        self.cov = hdul['BESTFIT'].data['covariance']
         self.params = {name: value for name, value in zip(self.names, self.mean)}
-        self.sigmas = {name: value for name, value in zip(self.names, hdul[2].data['errors'])}
+        self.sigmas = {
+            name: value for name, value in zip(self.names, hdul['BESTFIT'].data['errors'])}
         self.num_pars = len(self.names)
 
         if not results_only:
-            self.read_correlations(hdul[1])
+            self.read_correlations(hdul)
 
         hdul.close()
 
@@ -49,7 +57,53 @@ class FitResults:
         gaussian_samples = np.random.multivariate_normal(mean, cov, size=1000000)
         return MCSamples(samples=gaussian_samples, names=names, labels=list(labels.values()))
 
-    def read_correlations(self, hdu):
+    def read_correlations(self, hdul):
+        model_hdus = [hdu for hdu in hdul if hdu.name.startswith('MODEL')]
+        if len(model_hdus) == 0:
+            raise ValueError('No model HDUs found in the fit results file.')
+        elif model_hdus[0].name == 'MODEL':
+            self.old_read_correlations(model_hdus[0])
+            return
+
+        self.correlations = {}
+        self.num_data_points = 0
+        for hdu in model_hdus:
+            corr_name = hdu.name.split('_')[1]
+
+            model = hdu.data[corr_name + '_MODEL']
+            model_mask = hdu.data[corr_name + '_MODEL_MASK']
+            data = hdu.data[corr_name + '_DATA']
+            data_mask = hdu.data[corr_name + '_MASK']
+            self.num_data_points += len(data[data_mask])
+
+            variance = hdu.data[corr_name + '_VAR']
+            rp = hdu.data[corr_name + '_RP']
+            rt = hdu.data[corr_name + '_RT']
+            z = hdu.data[corr_name + '_Z']
+
+            size = hdu.header.get('HIERARCH SIZE', None)
+            chisq = hdu.header.get('HIERARCH CHISQ', None)
+            reduced_chisq = hdu.header.get('HIERARCH REDUCED_CHISQ', None)
+            p_value = hdu.header.get('HIERARCH P_VALUE', None)
+
+            if 'HIERARCH BESTFIT_MARG_COEFF_0' in hdu.header:
+                marg_coeffs = []
+                i = 0
+                while f'HIERARCH BESTFIT_MARG_COEFF_{i}' in hdu.header:
+                    marg_coeffs.append(hdu.header[f'HIERARCH BESTFIT_MARG_COEFF_{i}'])
+                    i += 1
+                bestfit_marg_coeff = np.array(marg_coeffs)
+
+            self.correlations[corr_name] = CorrelationOutput(
+                model, model_mask, data, data_mask, variance, rp, rt, z,
+                size=size, chisq=chisq, reduced_chisq=reduced_chisq,
+                p_value=p_value, bestfit_marg_coeff=bestfit_marg_coeff
+            )
+
+        self.p_value = 1 - stats.chi2.cdf(self.chisq, self.num_data_points - self.num_pars)
+        self.reduced_chisq = self.chisq / (self.num_data_points - self.num_pars)
+
+    def old_read_correlations(self, hdu):
         if len(hdu.data.columns) % 9 != 0:
             raise ValueError('Vega output format has changed. Please update fit reader.')
 

--- a/vega/power_spectrum.py
+++ b/vega/power_spectrum.py
@@ -42,6 +42,8 @@ class PowerSpectrum:
         self._bin_size_rt = config.getfloat('bin_size_rt')
         self.use_Gk = self._config.getboolean('model binning', True)
 
+        self.skip_nl_model_in_peak = config.getboolean('skip-nl-model-in-peak', True)
+
         # Damping scale for P(k) - used to match EFT behavior
         self.pk_damping_scale = config.getfloat('pk-damping-scale', None)
         self.pk_damping_power = config.getint('pk-damping-power', 2)
@@ -119,7 +121,8 @@ class PowerSpectrum:
         pk_full = pk_lin * self.compute_kaiser(bias1, beta1, bias2, beta2, fast_metals)
 
         # add non linear small scales
-        if 'small scale nl' in self._config.keys():
+        skip_nl = self.skip_nl_model_in_peak and params['peak']
+        if 'small scale nl' in self._config.keys() and not skip_nl:
             if 'arinyo' in self._config.get('small scale nl'):
                 pk_full *= self.compute_dnl_arinyo(params)
             elif 'mcdonald' in self._config.get('small scale nl'):

--- a/vega/power_spectrum.py
+++ b/vega/power_spectrum.py
@@ -42,7 +42,7 @@ class PowerSpectrum:
         self._bin_size_rt = config.getfloat('bin_size_rt')
         self.use_Gk = self._config.getboolean('model binning', True)
 
-        self.skip_nl_model_in_peak = config.getboolean('skip-nl-model-in-peak', True)
+        self.skip_nl_model_in_peak = config.getboolean('skip-nl-model-in-peak', False)
 
         # Damping scale for P(k) - used to match EFT behavior
         self.pk_damping_scale = config.getfloat('pk-damping-scale', None)

--- a/vega/scripts/run_vega.py
+++ b/vega/scripts/run_vega.py
@@ -31,8 +31,11 @@ def run_vega(config_path):
     if vega.minimizer is not None:
         for par, val in vega.bestfit.values.items():
             vega.params[par] = val
-    corr_funcs = vega.compute_model(vega.params, run_init=False)
-    vega.output.write_results(corr_funcs, vega.params, vega.minimizer, scan_results, vega.models)
+
+    vega.output.write_results(
+        vega.bestfit_model, vega.params, vega.minimizer, vega.bestfit_corr_stats,
+        scan_results, vega.models,
+    )
 
     plt.rc('axes', labelsize=16)
     plt.rc('axes', titlesize=16)

--- a/vega/templates/civxciv.ini
+++ b/vega/templates/civxciv.ini
@@ -7,10 +7,10 @@ tracer2-type = continuous
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/civxqso.ini
+++ b/vega/templates/civxqso.ini
@@ -7,10 +7,10 @@ tracer2-type = discrete
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/dlaxdla.ini
+++ b/vega/templates/dlaxdla.ini
@@ -7,10 +7,10 @@ tracer2-type = discrete
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/lyaxdla.ini
+++ b/vega/templates/lyaxdla.ini
@@ -7,10 +7,10 @@ tracer2-type = discrete
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/lyaxlya.ini
+++ b/vega/templates/lyaxlya.ini
@@ -7,10 +7,10 @@ tracer2-type = continuous
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/lyaxlyb.ini
+++ b/vega/templates/lyaxlyb.ini
@@ -7,10 +7,10 @@ tracer2-type = continuous
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/lyaxqso.ini
+++ b/vega/templates/lyaxqso.ini
@@ -7,10 +7,10 @@ tracer2-type = discrete
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/lybxdla.ini
+++ b/vega/templates/lybxdla.ini
@@ -7,10 +7,10 @@ tracer2-type = discrete
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/lybxqso.ini
+++ b/vega/templates/lybxqso.ini
@@ -7,10 +7,10 @@ tracer2-type = discrete
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/qsoxdla.ini
+++ b/vega/templates/qsoxdla.ini
@@ -7,10 +7,10 @@ tracer2-type = discrete
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/templates/qsoxqso.ini
+++ b/vega/templates/qsoxqso.ini
@@ -7,10 +7,10 @@ tracer2-type = discrete
 filename = path
 
 [cuts]
-rp-min = -200.
-rp-max = +200.
+rp-min = -300.
+rp-max = +300.
 rt-min = 0.
-rt-max = 200.
+rt-max = 300.
 r-min = 10.
 r-max = 180.
 mu-min = -1.

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -743,7 +743,7 @@ class VegaInterface:
             j = 0
             for i, name in enumerate(self.corr_items):
                 ndata = self.data[name].full_data_size
-                wd, wm = self.data[name].data_mask, self.data[name].model_mask
+                wd = self.data[name].data_mask
 
                 if self.corr_items[name].marginalize_small_scales:
                     M1 = self.global_cov[j:j + ndata, j:j + ndata]

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -740,27 +740,22 @@ class VegaInterface:
                 corr_item.marginalize_small_scales
                 for corr_item in self.corr_items.values()
         ):
-            # G = np.full((len(self.corr_items), len(self.corr_items)), None)
+            print('Updating global covariance with marginalization templates.')
             j = 0
             for i, name in enumerate(self.corr_items):
                 ndata = self.data[name].full_data_size
                 wd, wm = self.data[name].data_mask, self.data[name].model_mask
 
                 if self.corr_items[name].marginalize_small_scales:
-                    # G[i, i] = self.data[name].get_dist_xi_marg_templates()
                     M1 = self.global_cov[j:j + ndata, j:j + ndata]
                     w = np.logical_and.outer(wd, wd)
                     M1[w] += self.data[name].cov_marg_update
 
-                    self.data[name].cov_marg_update = None
+                    if self.low_mem_mode:
+                        del self.data[name].cov_marg_update
 
                 j += ndata
-
-            # cov_update = block_array(G, format='csr')
-            # cov_update = cov_update[self.full_model_mask, :][:, self.full_model_mask]
-            # w = np.logical_and.outer(self.full_data_mask, self.full_data_mask)
-            # self.global_cov[w] += cov_update.toarray().ravel()
-            # del w, cov_update
+            del j
 
         if self.low_mem_mode:
             masked_cov = self.global_cov[:, self.full_data_mask]

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -2,7 +2,6 @@
 import os.path
 import numpy as np
 import scipy.stats
-from scipy.sparse import block_array
 from astropy.io import fits
 import configparser
 import copy

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -435,20 +435,28 @@ class VegaInterface:
         num_pars = len(self.sample_params['limits'])
         print('\n----------------------------------------------------')
         for name in self.corr_items:
-            data_size = self.data[name].effective_data_size
+            data = self.data[name]
+            data_size = data.effective_data_size
             self.total_data_size += data_size
 
             if self.monte_carlo and self._use_global_cov:
                 # TODO Figure out a better way to handle this
                 chisq = 0
             elif self.monte_carlo:
-                diff = self.data[name].masked_mc_mock \
-                    - self.bestfit_model[name][self.data[name].model_mask]
-                chisq = diff.T.dot(self.data[name].scaled_inv_masked_cov.dot(diff))
+                diff = data.masked_mc_mock \
+                    - self.bestfit_model[name][data.model_mask]
+                chisq = diff.T.dot(data.scaled_inv_masked_cov.dot(diff))
             else:
-                diff = self.data[name].masked_data_vec \
-                    - self.bestfit_model[name][self.data[name].model_mask]
-                chisq = diff.T.dot(self.data[name].inv_masked_cov.dot(diff))
+                diff = data.masked_data_vec \
+                    - self.bestfit_model[name][data.model_mask]
+                chisq = diff.T.dot(data.inv_masked_cov.dot(diff))
+
+            # Calculate best-fitting values for the marginalized templates.
+            # This approximation ignores global_cov, hence correlations between
+            # CFs. Bestfit_model is updated in-place.
+            if data.marg_diff2coeff_matrix is not None:
+                bestfit_marg_coeff = data.marg_diff2coeff_matrix.dot(diff)
+                self.bestfit_model[name] += data.marg_templates.dot(bestfit_marg_coeff)
 
             reduced_chisq = chisq / (data_size - num_pars)
             p_value = 1 - scipy.stats.chi2.cdf(chisq, data_size - num_pars)

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -734,13 +734,13 @@ class VegaInterface:
         # More stable inversion can be achieved through Woodbury, but
         # requires handling masked pixels without removing them from cov.
         if any(
-                self.models[name].marginalization_templates is not None
-                for name in self.corr_items
+                corr_item.marginalize_small_scales
+                for corr_item in self.corr_items.values()
         ):
             G = np.full((len(self.corr_items), len(self.corr_items)), None)
             for i, name in enumerate(self.corr_items):
-                if self.models[name].marginalization_templates is not None:
-                    G[i, i] = self.models[name].marginalization_templates
+                if self.corr_items[name].marginalize_small_scales:
+                    G[i, i] = self.data[name].get_dist_xi_marg_templates()
 
             all_templates = block_array(G, format='csr')
 

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -750,8 +750,9 @@ class VegaInterface:
                     # G[i, i] = self.data[name].get_dist_xi_marg_templates()
                     M1 = self.global_cov[j:j + ndata, j:j + ndata]
                     w = np.logical_and.outer(wd, wd)
-                    M1[w] += self.data[name].get_dist_xi_marg_templates(
-                        )[wm, :][:, wm].ravel()
+                    M1[w] += self.data[name].cov_marg_update
+
+                    self.data[name].cov_marg_update = None
 
                 j += ndata
 

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -454,6 +454,7 @@ class VegaInterface:
             # Calculate best-fitting values for the marginalized templates.
             # This approximation ignores global_cov, hence correlations between
             # CFs. Bestfit_model is updated in-place.
+            bestfit_marg_coeff = None
             if data.marg_diff2coeff_matrix is not None:
                 bestfit_marg_coeff = data.marg_diff2coeff_matrix.dot(diff)
                 self.bestfit_model[name] += data.marg_templates.dot(bestfit_marg_coeff)
@@ -465,8 +466,10 @@ class VegaInterface:
                   f'= {reduced_chisq:.3f}, PTE={p_value:.2f}')
             print('----------------------------------------------------')
 
-            self.bestfit_corr_stats[name] = {'size': data_size, 'chisq': chisq,
-                                             'reduced_chisq': reduced_chisq, 'p_value': p_value}
+            self.bestfit_corr_stats[name] = {
+                'size': data_size, 'chisq': chisq, 'reduced_chisq': reduced_chisq,
+                'p_value': p_value, 'bestfit_marg_coeff': bestfit_marg_coeff
+            }
 
         self.chisq = self.minimizer.fmin.fval
         self.reduced_chisq = self.chisq / (self.total_data_size - num_pars)

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -741,7 +741,7 @@ class VegaInterface:
         ):
             print('Updating global covariance with marginalization templates.')
             j = 0
-            for i, name in enumerate(self.corr_items):
+            for name in self.corr_items:
                 ndata = self.data[name].full_data_size
                 wd = self.data[name].data_mask
 

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -467,7 +467,7 @@ class VegaInterface:
             print('----------------------------------------------------')
 
             self.bestfit_corr_stats[name] = {
-                'size': data_size, 'chisq': chisq, 'reduced_chisq': reduced_chisq,
+                'masked_size': data_size, 'chisq': chisq, 'reduced_chisq': reduced_chisq,
                 'p_value': p_value, 'bestfit_marg_coeff': bestfit_marg_coeff
             }
 

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -742,16 +742,16 @@ class VegaInterface:
             print('Updating global covariance with marginalization templates.')
             j = 0
             for name in self.corr_items:
-                ndata = self.data[name].full_data_size
-                wd = self.data[name].data_mask
+                data = self.data[name]
+                ndata = data.full_data_size
+                wd = data.data_mask
 
                 if self.corr_items[name].marginalize_small_scales:
                     M1 = self.global_cov[j:j + ndata, j:j + ndata]
-                    w = np.logical_and.outer(wd, wd)
-                    M1[w] += self.data[name].cov_marg_update
+                    M1[np.ix_(wd, wd)] += data.cov_marg_update
 
                     if self.low_mem_mode:
-                        del self.data[name].cov_marg_update
+                        del data.cov_marg_update
 
                 j += ndata
             del j

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -435,7 +435,7 @@ class VegaInterface:
         num_pars = len(self.sample_params['limits'])
         print('\n----------------------------------------------------')
         for name in self.corr_items:
-            data_size = self.data[name].data_size
+            data_size = self.data[name].effective_data_size
             self.total_data_size += data_size
 
             if self.monte_carlo and self._use_global_cov:


### PR DESCRIPTION
Implemented mode marginalization. I am using the following transformation: $$\mathbf{C} \rightarrow \mathbf{C} + \mathbf{F} \mathbf{S}\mathbf{F}^\mathrm{T}$$, where $\mathbf{F}$ is the template matrix of shape (ndata, ntemplates) and $\mathbf{S}$ is the diagonal prior variance matrix. Uninformative marginalization requires $S\rightarrow \infty$, but a large number will be enough. The template matrix is also compressed to non-degenerate modes using SVD, which takes a while to calculate.


Co-pilot can summarize code and config changes more effectively.